### PR TITLE
Update scikit-learn requirement to version 0.1.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="panco2",
-    version="0.1.0",
+    version="0.1.1",
     description="panco2: pressure profile fitter from tSZ observations",
     author="Florian Keruzore",
     author_email="fkeruzore@anl.gov",
@@ -17,6 +17,6 @@ setup(
         "tqdm",
         "dill",
         "chainconsumer",
-        "sklearn",
+        "scikit-learn",
     ],
 )


### PR DESCRIPTION
This pull request updates the scikit-learn requirement in the project's setup.py file from "sklearn" to "scikit-learn" and sets the version to 0.1.1. This change ensures that the correct package is installed when setting up the project.